### PR TITLE
Fix/incorrect specs when not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Changelog for 2.2.3
+
+### Bugfix
+
+  * When there is no default and it's not required, a variable should have the
+    variable's type and `nil` as return value e.g. for the variable `:my_var`
+    that returns integer, the spec would be as follows:
+
+    ```elixir
+    @spec my_var() :: {:ok, nil | integer()} | {:error, binary()}
+    ```
+
 ## Changelog for 2.2.2
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -429,6 +429,18 @@ the following:
 > **Note**: The same applies for `my_port!/0`, `reload_my_port/0` and
 > `put_my_port/1`.
 
+Specs are generated following the following table:
+
+Assuming the type is set to `:integer` explicitly (`type: :integer`) or
+implicitly (`default: 4000`), the specs should follow the following table:
+
+Required     | Has default     | Spec
+:----------: | :-------------: | :----
+`true`       | `true`          | `@spec my_port() :: {:ok, integer()} \| {:error, binary()}`
+`true`       | `false`         | `@spec my_port() :: {:ok, integer()} \| {:error, binary()}`
+`false`      | `true`          | `@spec my_port() :: {:ok, integer()} \| {:error, binary()}`
+`false`      | `false`         | `@spec my_port() :: {:ok, nil \| integer()} \| {:error, binary()}`
+
 ## Automatic template generation
 
 Every Skogsra module includes the functions `template/1` and `template/2` for

--- a/lib/skogsra/spec.ex
+++ b/lib/skogsra/spec.ex
@@ -57,21 +57,30 @@ defmodule Skogsra.Spec do
   # Helpers
 
   # Get the spec type given a configuration.
-  defp get_spec_type(:binary), do: quote(do: binary())
-  defp get_spec_type(:integer), do: quote(do: integer())
-  defp get_spec_type(:float), do: quote(do: float())
-  defp get_spec_type(:boolean), do: quote(do: boolean())
-  defp get_spec_type(:atom), do: quote(do: atom())
-  defp get_spec_type(:module), do: quote(do: module())
-  defp get_spec_type(:unsafe_module), do: quote(do: module())
-  defp get_spec_type(:any), do: quote(do: any())
+  defp get_spec_type(type, present?)
 
-  defp get_spec_type({:__aliases__, _, _} = module),
-    do: quote(do: unquote(module).t())
+  defp get_spec_type(:binary, true), do: quote(do: binary())
+  defp get_spec_type(:integer, true), do: quote(do: integer())
+  defp get_spec_type(:float, true), do: quote(do: float())
+  defp get_spec_type(:boolean, true), do: quote(do: boolean())
+  defp get_spec_type(:atom, true), do: quote(do: atom())
+  defp get_spec_type(:module, true), do: quote(do: module())
+  defp get_spec_type(:unsafe_module, true), do: quote(do: module())
+  defp get_spec_type(:any, true), do: quote(do: any())
+
+  defp get_spec_type({:__aliases__, _, _} = module, true) do
+    quote do: unquote(module).t()
+  end
+
+  defp get_spec_type(other, false) do
+    quote do: nil | unquote(get_spec_type(other, true))
+  end
 
   defp get_spec_type(options) when is_list(options) do
-    %Env{options: options}
-    |> Env.type()
-    |> get_spec_type()
+    env = %Env{options: options}
+    type = Env.type(env)
+    present? = Env.required?(env) or not is_nil(Env.default(env))
+
+    get_spec_type(type, present?)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Skogsra.Mixfile do
   use Mix.Project
 
-  @version "2.2.2"
+  @version "2.2.3"
   @root "https://github.com/gmtprime/skogsra"
 
   def project do


### PR DESCRIPTION
This PR fixes #13

Assuming the type is set to `:integer` explicitly (`type: :integer`) or implicitly (`default: 4000`), the specs should follow the following rules:

Required | Has default | Spec
:----------: | :-------------: | :----
`true`       | `true`          | `@spec my_port() :: {:ok, integer()} \| {:error, binary()}`
`true`       | `false`         | `@spec my_port() :: {:ok, integer()} \| {:error, binary()}` 
`false`      | `true`          | `@spec my_port() :: {:ok, integer()} \| {:error, binary()}` 
`false`      | `false`         | `@spec my_port() :: {:ok, nil \| integer()} \| {:error, binary()}`

In other words, when there is **no default** and is **not required** then the spec should be as the one you'd expect e.g. for the following declaration:

```elixir
defmodule Config do
  use Skogsra

  app_env :my_port, :myapp, :port 
end
```

we would expect the following spec:

```elixir
@spec my_port() :: {:ok, nil | integer()} | {:error, binary()}
```