### PR TITLE
Feat/add preload function to override elixir config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Changelog for 2.3.0
+
+### Enhancements
+
+  * Added `preload/0` and `preload/1` functions for overriding Elixir config
+    values when config providers and OS system variables have precedence.
+
 ## Changelog for 2.2.3
 
 ### Bugfix

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Additional topics:
 - [Explicit type casting](#explicit-type-casting).
 - [Explicit OS environment variable names](#explicit-os-environment-variable-name).
 - [Required variables](#required-variables).
-- [Caching variables](#caching-variables).
 - [Overriding Elixir Configuration](#overriding-elixir-configuration).
+- [Caching variables](#caching-variables).
 - [Handling different environments](#handling-different-environments).
 - [Setting and reloading variables](#setting-and-reloading-variables).
 - [Automatic docs generation](#automatic-docs-generation).
@@ -349,26 +349,6 @@ end
 ...
 ```
 
-## Caching variables
-
-By default, Skogsrå caches the values of the variables using
-`:persistent_term` Erlang module. This makes reads very fast, but **writes are
-very slow**.
-
-So avoid setting or reloading values to avoid performance issues (see
-[Setting and reloading variables](#setting-and-reloading-variables)).
-
-If you don't want to cache the values, you can set it to `false`:
-
-```elixir
-defmodule MyApp.Config do
-  use Skogsra
-
-  app_env :value, :myapp, :value,
-    cached: false
-end
-```
-
 ## Overriding Elixir Configuration
 
 Not all the libraries will use Skogsrå and, though is a shame, we can always
@@ -454,6 +434,29 @@ end
 
 The function `MyappWeb.Config.preload/1` will override any configuration for
 `MyappWeb.Endpoint` as long as is a runtime config.
+
+Our app now will try to get the port and secret key from the OS environment
+variables first and it will fallback to the defaults.
+
+## Caching variables
+
+By default, Skogsrå caches the values of the variables using
+`:persistent_term` Erlang module. This makes reads very fast, but **writes are
+very slow**.
+
+So avoid setting or reloading values to avoid performance issues (see
+[Setting and reloading variables](#setting-and-reloading-variables)).
+
+If you don't want to cache the values, you can set it to `false`:
+
+```elixir
+defmodule MyApp.Config do
+  use Skogsra
+
+  app_env :value, :myapp, :value,
+    cached: false
+end
+```
 
 ## Setting and reloading variables
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ config :myapp_web, MyappWeb.Endpoint,
   secret_key_base: secret_key_base
 ```
 
-With Skogsrå we can reduce the config as follows:
+With Skogsrå, we can reduce the config to the following:
 
 ```elixir
 use Mix.Config

--- a/lib/skogsra.ex
+++ b/lib/skogsra.ex
@@ -100,7 +100,7 @@ defmodule Skogsra do
       def preload(namespace \\ nil) do
         namespace
         |> __get_all_envs__()
-        |> Enum.map(&App.preload/1)
+        |> Enum.each(&App.preload/1)
 
         :ok
       end

--- a/lib/skogsra.ex
+++ b/lib/skogsra.ex
@@ -12,6 +12,7 @@ defmodule Skogsra do
   end
   ```
   """
+  alias Skogsra.App
   alias Skogsra.Core
   alias Skogsra.Docs
   alias Skogsra.Env
@@ -91,6 +92,19 @@ defmodule Skogsra do
         end
       end
 
+      @doc """
+      Preloads all variables in a `namespace` if supplied.
+      """
+      @spec preload() :: :ok
+      @spec preload(Env.namespace()) :: :ok
+      def preload(namespace \\ nil) do
+        namespace
+        |> __get_all_envs__()
+        |> Enum.map(&App.preload/1)
+
+        :ok
+      end
+
       @spec __get_definitions__(keyword()) :: [Template.t()]
       defp __get_definitions__(options) do
         namespace = options[:namespace]
@@ -108,10 +122,8 @@ defmodule Skogsra do
 
       @spec __get_required_errors__(Env.namespace()) :: [binary()]
       defp __get_required_errors__(namespace) do
-        @definitions
-        |> Stream.map(fn {_docs, name} ->
-          apply(__MODULE__, name, [namespace])
-        end)
+        namespace
+        |> __get_all_envs__()
         |> Stream.filter(&Env.required?/1)
         |> Enum.reduce([], fn env, errors ->
           case Core.get_env(env) do
@@ -122,6 +134,13 @@ defmodule Skogsra do
               [error | errors]
           end
         end)
+      end
+
+      @spec __get_all_envs__(Env.namespace()) :: Stream.t()
+      defp __get_all_envs__(namespace) do
+        @definitions
+        |> Stream.map(&elem(&1, 1))
+        |> Stream.map(&apply(__MODULE__, &1, [namespace]))
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Skogsra.Mixfile do
   use Mix.Project
 
-  @version "2.2.3"
+  @version "2.3.0"
   @root "https://github.com/gmtprime/skogsra"
 
   def project do


### PR DESCRIPTION
This PR adds a preload function to override application config values at runtime to give precedence to OS variables or config providers.

Let's say we have a Phoenix application and we want to configure our endpoint
with the following variables.

- The OS environment variable `PORT` for our app's HTTP port.
- The OS environment variable `SECRET_KEY_BASE` for our secret key base.

A regular Phoenix configuration will look like the following:

```elixir
use Mix.Config

secret_key_base =
  System.get_env("SECRET_KEY_BASE") ||
    raise """
    environment variable SECRET_KEY_BASE is missing.
    You can generate one by calling: mix phx.gen.secret
    """

config :myapp_web, MyappWeb.Endpoint,
  http: [
    port: String.to_integer(System.get_env("PORT") || "4000"),
    transport_options: [socket_opts: [:inet6]]
  ],
  secret_key_base: secret_key_base
```

With Skogsrå, we can reduce the config to the following:

```elixir
use Mix.Config

config :myapp_web, Myapp.Endpoint,
  http: [
    transport_options: [socket_opts: [:inet6]]
  ]
```

Then, handle our variables in our Skogsrå config module:

```elixir
defmodule MyappWeb.Config do
  use Skogsra

  @envdoc """
  App port.
  """
  app_env :port, :myapp, [:http, :port],
    os_env: "PORT",
    default: 4000

  @envdoc """
  Secret key base.
  """
  app_env :secret_key_base, :myapp, :secret_key_base,
    os_env: "SECRET_KEY_BASE",
    default: "+/JwMGGtsTVOoX5gQrCMn8aHKfKDdUK8GeAKJ2fIUabUnmWTwg+zsCy4pAOmOdTs"
end
```

And finally calling the preload function in our application init:

```elixir
defmodule MyappWeb.Application do
  @doc false
  use Application

  def start(_type, _args) do
    MyappWeb.Config.preload(MyappWeb.Endpoint)
    children = [
      MyappWeb.Endpoint
    ]
    
    (...)
  end
end
```

The function `MyappWeb.Config.preload/1` will override any configuration for
`MyappWeb.Endpoint` as long as is a runtime config.

Our app now will try to get the port and secret key from the OS environment
variables first and it will fallback to the defaults.