### PR TITLE
Defaults per environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Changelog for 2.5.0
+
+### Enhancements
+
+  * Added `env_overrides` for overriding  `default` and `required` attributes
+    per environment (e.g. `dev`, `test`, `prod`).
+
 ## Changelog for 2.4.2
 
 ### Bugfix

--- a/README.md
+++ b/README.md
@@ -981,7 +981,7 @@ in `mix.exs` (Elixir ≥ 1.11 and Erlang ≥ 22):
 ```elixir
 def deps do
   [
-    {:skogsra, "~> 2.4"}
+    {:skogsra, "~> 2.5"}
   ]
 end
 ```
@@ -991,7 +991,7 @@ If you need YAML config provider support, add the following:
 ```elixir
 def deps do
   [
-    {:skogsra, "~> 2.4"},
+    {:skogsra, "~> 2.5"},
     {:yamerl, "~> 0.10"}
   ]
 end
@@ -1002,7 +1002,7 @@ If you need JSON config provider support, add  the following:
 ```elixir
 def deps do
   [
-    {:skogsra, "~> 2.4"},
+    {:skogsra, "~> 2.5"},
     {:jason, "~> 1.4"}
   ]
 end

--- a/lib/skogsra.ex
+++ b/lib/skogsra.ex
@@ -165,6 +165,7 @@ defmodule Skogsra do
   `required`      | `boolean`               | `false`              | Whether the variable is required or not.
   `cached`        | `boolean`               | `true`               | Whether the variable should be cached or not.
   `namespace`     | `module`                | `nil`                | Overrides any namespace.
+  `env_overrides` | `keyword`               | `[]`                 | Overrides `default` and `required` properties for a specific environment.
 
   e.g:
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Skogsra.Mixfile do
   use Mix.Project
 
-  @version "2.4.2"
+  @version "2.5.0"
   @name "Skogsrå"
   @description "Manages OS environment variables and application configuration options with ease"
   @app :skogsra

--- a/test/skogsra/core_test.exs
+++ b/test/skogsra/core_test.exs
@@ -39,6 +39,20 @@ defmodule Skogsra.CoreTest do
 
       assert {:error, ^expected} = Core.get_env(env)
     end
+
+    test "when value is required for the environment, returns error message" do
+      options = [
+        required: false,
+        env_overrides: [test: [required: true]],
+        binding_skip: [:system, :config]
+      ]
+
+      env = Env.new(nil, :core_app, :key, options)
+
+      expected = "Variable key in app core_app is undefined"
+
+      assert {:error, ^expected} = Core.get_env(env)
+    end
   end
 
   describe "get_env!/1" do
@@ -55,6 +69,17 @@ defmodule Skogsra.CoreTest do
       env = Env.new(nil, :core_app, :key, options)
 
       assert is_nil(Core.get_env!(env))
+    end
+
+    test "when doesn't exist, returns environment default" do
+      options = [
+        binding_skip: [:system, :config],
+        env_overrides: [test: [default: 42]]
+      ]
+
+      env = Env.new(nil, :core_app, :key, options)
+
+      assert 42 = Core.get_env!(env)
     end
 
     test "when doesn't exist and it's required, fails" do

--- a/test/skogsra/env_test.exs
+++ b/test/skogsra/env_test.exs
@@ -68,6 +68,16 @@ defmodule Skogsra.EnvTest do
 
       assert 42 = Env.default(env)
     end
+
+    test "should get the default value for the current environment" do
+      env =
+        Env.new(nil, :app, :key,
+          default: 0,
+          env_overrides: [test: [default: 42]]
+        )
+
+      assert 42 = Env.default(env)
+    end
   end
 
   describe "required?/1" do
@@ -79,6 +89,16 @@ defmodule Skogsra.EnvTest do
 
     test "gets value for required if set" do
       env = Env.new(nil, :app, :key, required: true)
+
+      assert Env.required?(env)
+    end
+
+    test "should get the required value for the current environment" do
+      env =
+        Env.new(nil, :app, :key,
+          required: false,
+          env_overrides: [test: [required: true]]
+        )
 
       assert Env.required?(env)
     end
@@ -169,6 +189,12 @@ defmodule Skogsra.EnvTest do
 
     test "when other" do
       assert :any == Env.get_type([])
+    end
+  end
+
+  describe "find_environment/0" do
+    test "should get the current environment" do
+      assert :test = Env.find_environment()
     end
   end
 end

--- a/test/skogsra/provider/yaml_test.exs
+++ b/test/skogsra/provider/yaml_test.exs
@@ -119,24 +119,7 @@ if Code.ensure_loaded?(Config.Provider) do
 
         assert [
                  yggdrasil: [
-                   {
-                     MyApp.Namespace,
-                     [
-                       postgres: [
-                         username: "postgres_username",
-                         password: "postgres_password",
-                         database: "postgres_database",
-                         hostname: "localhost",
-                         port: 5432
-                       ],
-                       rabbitmq: [
-                         username: "rabbitmq_username",
-                         password: "rabbitmq_password",
-                         hostname: "localhost",
-                         port: 7652
-                       ]
-                     ]
-                   },
+                   {MyApp.Namespace, apps},
                    {
                      MyApp.OtherNamespace,
                      [
@@ -151,6 +134,21 @@ if Code.ensure_loaded?(Config.Provider) do
                    }
                  ]
                ] = Yaml.load([], path)
+
+        assert [
+                 username: "postgres_username",
+                 password: "postgres_password",
+                 database: "postgres_database",
+                 hostname: "localhost",
+                 port: 5432
+               ] = apps[:postgres]
+
+        assert [
+                 username: "rabbitmq_username",
+                 password: "rabbitmq_password",
+                 hostname: "localhost",
+                 port: 7652
+               ] = apps[:rabbitmq]
       end
 
       test "returns same config if the configuration is not found" do


### PR DESCRIPTION
This PR adds the possibility of setting both `default` and `required` attributes for each environment

## Problem

Either using Skogsra or using plain Elixir, we need to check into several config files to have a full picture of the configuration of an environment e.g. let's say our database configuration requires the following configuration:

- For `dev`:
```elixir
# ./config/dev.exs
config :myapp, Myapp.Repo,
  username: "postgres",
  password: "postgres",
  hostname: "localhost",
  port: 5432,
  database: "myapp_dev"
```
- For `test`:
```elixir
# ./config/test.exs
config :myapp, Myapp.Repo,
  username: "postgres",
  password: "postgres",
  hostname: "localhost",
  port: 5432,
  database: "myapp_test"
```
- For `prod`:
```elixir
# ./config/runtime.exs

if config_env() == :prod do
  database_url = System.get_env("DATABASE_URL") || raise "no database url",

  config :myapp, Myapp.Repo,
    url: database_url
end
```

With that setup, we need to open three files to realize:
- `dev` and `test` environments cannot use the `DATABASE_URL` to connect to the database.
- `dev` and `test` environments have a different database name.
- `prod` environment needs the `DATABASE_URL` OR environment variable, otherwise it will raise.

## Solution

With Skogsra, we can have the same configuration but in a single file:

```elixir
defmodule Myapp.Config do
  use Skogsra

  @envdoc "DB username"
  app_env :db_username, :myapp, [Myapp.Repo, :username],
    env_overrides: [
      dev: [default: "postgres"],
      test: [default: "postgres"]
    ]

  @envdoc "DB password"
  app_env :db_password, :myapp, [Myapp.Repo, :password],
    env_overrides: [
      dev: [default: "postgres"],
      test: [default: "postgres"]
    ]

  @envdoc "DB hostname"
  app_env :db_hostname, :myapp, [Myapp.Repo, :hostname],
    env_overrides: [
      dev: [default: "localhost"],
      test: [default: "localhost"]
    ]

  @envdoc "DB port"
  app_env :db_port, :myapp, [Myapp.Repo, :port],
    type: :integer,
    env_overrides: [
      dev: [default: 5432],
      test: [default: 5432]
    ]

  @envdoc "DB name"
  app_env :db_name, :myapp, [Myapp.Repo, :database],
    env_overrides: [
      dev: [default: "myapp_dev"],
      test: [default: "myapp_test"]
    ]

  @envdoc "DB URL"
  app_env :db_url, :myapp, [Myapp.Repo, :url],
    type: :binary,
    os_env: "DATABASE_URL",
    env_overrides: [
      prod: [required: true]
    ]
end
```

Both `dev` and `test` environments have default values for the `username`,
`password`, `hostname`, `port` and `database` configuration variables while
the `url` value is `nil` by default.

However, for `prod` enviroment, there are no defaults and all of them are
actually `nil`. Instead, `prod` requires for the `url` to be defined and it
doesn't provide any `default` value.

If, additionally, we have the following code in place in our application start: 

```elixir
Myapp.Config.preload()
Myapp.Config.validate()
```

we can ensure the OS environment variable `DATABASE_URL` is a required value for `prod` environment only.

![](https://media.giphy.com/media/Qbew2BRZn5rmagRzPx/giphy.gif)