### PR TITLE
:bug: Type spec errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Changelog for 2.5.2
+
+### Bugfix
+
+  * When passing strings keys, dialyzer was failing.
+
 ## Changelog for 2.5.1
 
 ### Bugfix

--- a/lib/skogsra.ex
+++ b/lib/skogsra.ex
@@ -216,6 +216,9 @@ defmodule Skogsra do
      ```
   5. From the default value if it exists. In our example, `"password"`.
   """
+  @spec app_env(atom(), atom(), atom() | binary() | [any()]) :: Macro.t()
+  @spec app_env(atom(), atom(), atom() | binary() | [any()], keyword()) ::
+          Macro.t()
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defmacro app_env(function_name, app_name, keys, options \\ []) do
     definition = String.to_atom("__#{function_name}__")

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Skogsra.Mixfile do
   use Mix.Project
 
-  @version "2.5.1"
+  @version "2.5.2"
   @name "Skogsrå"
   @description "Manages OS environment variables and application configuration options with ease"
   @app :skogsra


### PR DESCRIPTION
While using the `binary()` keys, Dialyzer started throwing a bunch of warning. This PR is an attempt to fix the issues.

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExemllZWRpNWd3c3VrOTRuMXVpdDNpc2Jxa3UyMGc1aThudXZweDdrcSZlcD12MV9naWZzX3RyZW5kaW5nJmN0PWc/FY8c5SKwiNf1EtZKGs/giphy.gif)